### PR TITLE
fix: support Ayatana AppIndicator builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,27 +7,45 @@ project(ClevoFanControl C)
 # Enable the language standard.
 set(CMAKE_C_STANDARD 99)
 
-# Explicitly link the math library.
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -lm")
-
 # Add the main executable.
 add_executable(clevo-fan-control src/main.c)
 
 # Use the package PkgConfig to detect dependencies.
 find_package(PkgConfig REQUIRED)
-pkg_check_modules(APPINDICATOR REQUIRED appindicator3-0.1)
+
+# Prefer the legacy AppIndicator package when available, but fall back to
+# Ayatana AppIndicator. Newer Debian/Ubuntu releases ship Ayatana instead of
+# appindicator3-0.1.
+pkg_check_modules(APPINDICATOR appindicator3-0.1)
+if(NOT APPINDICATOR_FOUND)
+        pkg_check_modules(APPINDICATOR REQUIRED ayatana-appindicator3-0.1)
+        target_compile_definitions(clevo-fan-control PRIVATE USE_AYATANA_APPINDICATOR)
+endif()
+
 pkg_check_modules(GTK3 REQUIRED gtk+-3.0)
 
 # Include the dependencies.
-include_directories(${APPINDICATOR_INCLUDE_DIRS})
-include_directories(${GTK3_INCLUDE_DIRS})
-link_directories(${GTK3_LIBRARY_DIRS})
+target_include_directories(clevo-fan-control PRIVATE
+        ${APPINDICATOR_INCLUDE_DIRS}
+        ${GTK3_INCLUDE_DIRS}
+)
 
-# Add other flags to the compiler
-add_definitions(${GTK3_CFLAGS_OTHER})
+target_link_directories(clevo-fan-control PRIVATE
+        ${APPINDICATOR_LIBRARY_DIRS}
+        ${GTK3_LIBRARY_DIRS}
+)
+
+target_compile_options(clevo-fan-control PRIVATE
+        ${APPINDICATOR_CFLAGS_OTHER}
+        ${GTK3_CFLAGS_OTHER}
+)
 
 # Link the target to the dependencies.
-target_link_libraries(clevo-fan-control ${APPINDICATOR_LIBRARIES} ${GTK3_LIBRARIES})
+target_link_libraries(clevo-fan-control
+        ${APPINDICATOR_LIBRARIES}
+        ${GTK3_LIBRARIES}
+        m
+)
 
 # Specify installation rules.
 install(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,23 +24,26 @@ endif()
 
 pkg_check_modules(GTK3 REQUIRED gtk+-3.0)
 
-# Include the dependencies.
+# Include dependency headers for this target.
 target_include_directories(clevo-fan-control PRIVATE
         ${APPINDICATOR_INCLUDE_DIRS}
         ${GTK3_INCLUDE_DIRS}
 )
 
+# Add dependency library search paths for this target.
 target_link_directories(clevo-fan-control PRIVATE
         ${APPINDICATOR_LIBRARY_DIRS}
         ${GTK3_LIBRARY_DIRS}
 )
 
+# Add dependency-specific compiler flags for this target.
 target_compile_options(clevo-fan-control PRIVATE
         ${APPINDICATOR_CFLAGS_OTHER}
         ${GTK3_CFLAGS_OTHER}
 )
 
-# Link the target to the dependencies.
+# Link the target to AppIndicator/GTK and libm. round() is provided by libm,
+# so it needs to be modeled as a link dependency instead of a compiler flag.
 target_link_libraries(clevo-fan-control
         ${APPINDICATOR_LIBRARIES}
         ${GTK3_LIBRARIES}

--- a/README.md
+++ b/README.md
@@ -12,8 +12,17 @@ package manager available for your Linux distribution.
 
 - GCC
 - CMake
-- AppIndicator3
+- AppIndicator3 or Ayatana AppIndicator3
 - GTK+3
+
+On Debian/Ubuntu systems that ship Ayatana AppIndicator, install:
+
+```shell
+sudo apt install build-essential cmake pkg-config libgtk-3-dev libayatana-appindicator3-dev
+```
+
+On systems that still ship the legacy AppIndicator package, install the
+corresponding `libappindicator3-dev` package instead.
 
 ## Build and Install
 

--- a/src/main.c
+++ b/src/main.c
@@ -45,7 +45,18 @@
 #include <unistd.h>
 #include <time.h>
 
+#ifdef USE_AYATANA_APPINDICATOR
+#include <libayatana-appindicator/app-indicator.h>
+/*
+ * Ayatana AppIndicator has used both IS_APP_INDICATOR and
+ * APP_IS_INDICATOR across releases. Keep the existing source call portable.
+ */
+#ifndef IS_APP_INDICATOR
+#define IS_APP_INDICATOR APP_IS_INDICATOR
+#endif
+#else
 #include <libappindicator/app-indicator.h>
+#endif
 
 #define NAME "clevo-indicator"
 


### PR DESCRIPTION
## Summary

This updates the build to work on newer Debian/Ubuntu-based systems where `appindicator3-0.1` is no longer available and `ayatana-appindicator3-0.1` is provided instead.

Changes:
- Prefer legacy `appindicator3-0.1` when available.
- Fall back to `ayatana-appindicator3-0.1` when legacy AppIndicator is missing.
- Use the appropriate Ayatana header and handle the `IS_APP_INDICATOR` / `APP_IS_INDICATOR` macro difference across releases.
- Link `libm` with `target_link_libraries(... m)` so `round()` resolves correctly at link time.
- Document Debian/Ubuntu dependencies for the Ayatana path.

## Test plan

Built successfully on Ubuntu 24.04 with only Ayatana AppIndicator development headers installed:

```text
cmake ..
cmake --build . --verbose
[100%] Built target clevo-fan-control
```